### PR TITLE
refactor: drop JS support and rely on TS paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": false,
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "target": "ES6",
     "skipLibCheck": true,
     "strict": true,
@@ -18,10 +21,20 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- remove legacy allowJs flag from TS config
- configure baseUrl to keep `@/` imports working without jsconfig

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm build` *(fails: Failed to fetch Inter font; Module not found: Can't resolve '@hookform/resolvers/zod')*

------
https://chatgpt.com/codex/tasks/task_e_68bec52a2f608326a5199c3b09648d2a